### PR TITLE
#918 Filter access and customize organization-management views

### DIFF
--- a/app/organization-management/js/router.js
+++ b/app/organization-management/js/router.js
@@ -29,13 +29,21 @@ function (Backbone, singletonDecorator) {
         },
 
         organizationEdit:function() {
-            this.refresh();
-            App.appView.organizationEdit();
+            if(App.config.organization.owner !== App.config.login) {
+                Backbone.history.navigate('', { trigger : true });
+            } else {
+                this.refresh();
+                App.appView.organizationEdit();
+            }
         },
 
         organizationMembers:function() {
-            this.refresh();
-            App.appView.organizationMembers();
+            if(Object.keys(App.config.organization).length > 0) {
+                this.refresh();
+                App.appView.organizationMembers();
+            } else {
+                Backbone.history.navigate('', { trigger : true });
+            }
         }
     });
 

--- a/app/organization-management/js/templates/organization-management-home.html
+++ b/app/organization-management/js/templates/organization-management-home.html
@@ -27,7 +27,9 @@
             </ul>
 
             <div class="organization-actions">
+                {{#isOwner}}
                 <a href="#/edit">{{i18n.EDIT}}</i></a>
+                {{/isOwner}}
             </div>
         </div>
     </div>

--- a/app/organization-management/js/templates/organization-members.html
+++ b/app/organization-management/js/templates/organization-members.html
@@ -3,9 +3,11 @@
         {{i18n.BACK}}
     </button>
 
+    {{#isOwner}}
     <button class="btn btn-default add-user" title="{{i18n.ADD_USER}}">
         <i class="fa fa-plus"></i> {{i18n.ADD_USER}}
     </button>
+    {{/isOwner}}
 
     <form id="organization-add-user-form" class="inline form-inline hide">
         <input type="text" required name="login" placeholder="{{i18n.LOGIN}}"/>
@@ -40,7 +42,9 @@
             <table id="organization_user_table" class="table table-striped table-condensed">
                 <thead>
                     <tr>
+                        {{#isOwner}}
                         <th><input type="checkbox" class="toggle-checkboxes"></th>
+                        {{/isOwner}}
                         <th>{{i18n.NAME}}</th>
                         <th>{{i18n.EMAIL}}</th>
                     </tr>
@@ -48,7 +52,9 @@
                 <tbody class="items">
                 {{#members}}
                     <tr>
+                        {{#isOwner}}
                         <td><input type="checkbox" class="toggle-checkbox" data-is-admin="{{isCurrentAdmin}}" data-login="{{login}}"/></td>
+                        {{/isOwner}}
                         <td>{{name}}</td>
                         <td>{{email}}</td>
                     </tr>

--- a/app/organization-management/js/views/organization-management-home.js
+++ b/app/organization-management/js/views/organization-management-home.js
@@ -23,6 +23,7 @@ define([
 
             this.$el.html(Mustache.render(template, {
                 organization:App.config.organization,
+                isOwner:(App.config.login === App.config.organization.owner),
                 organizationName:App.config.organization.name,
                 i18n: App.config.i18n
             }));

--- a/app/organization-management/js/views/organization-members.js
+++ b/app/organization-management/js/views/organization-members.js
@@ -34,6 +34,7 @@ define([
             }).then(function() {
                 _this.$el.html(Mustache.render(template, {
                     i18n: App.config.i18n,
+                    isOwner:(App.config.login === App.config.organization.owner),
                     members:_this.members
                 }));
                 _this.bindDOMElements();


### PR DESCRIPTION
/!\ BE CAREFUL /!\ This PR needs [polarsys/eplmp PR#33](https://github.com/polarsys/eplmp/pull/33) to work. Don't merge it before!

The organization-management router now filters access on organizationEdit and organizationMembers and redirect unauthorized users to home.
Only organization owner can now see buttons and inputs that are only usable by him.