### PR TITLE
Fix issue with advanced search query

### DIFF
--- a/app/document-management/js/views/advanced_search.js
+++ b/app/document-management/js/views/advanced_search.js
@@ -7,8 +7,9 @@ define([
     'common-objects/views/attributes/attribute_list',
     'collections/template',
     'common-objects/utils/date',
+    'common-objects/utils/query',
     'common-objects/collections/lovs'
-], function (Backbone,Mustache, template, Users, DocumentAttributeListView, Templates, date,LOVCollection) {
+], function (Backbone,Mustache, template, Users, DocumentAttributeListView, Templates, date, query, LOVCollection) {
     'use strict';
     var AdvancedSearchView = Backbone.View.extend({
 
@@ -140,72 +141,20 @@ define([
 
         constructQueryString: function () {
 
-            var id = this.$id.val();
-            var title = this.$title.val();
-            var type = this.$type.val();
-            var version = this.$version.val();
-            var author = this.$author.val();
-            var tags = this.$tags.val().replace(/ /g, '');
-            var content = this.$content.val();
-            var createdFrom = this.$createdFrom.val();
-            var createdTo = this.$createdTo.val();
-            var modifiedFrom = this.$modifiedFrom.val();
-            var modifiedTo = this.$modifiedTo.val();
-
-            var queryString = '';
-
-            if (id) {
-                queryString += '&id=' + id;
-            }
-            if (title) {
-                queryString += '&title=' + title;
-            }
-            if (type) {
-                queryString += '&type=' + type;
-            }
-            if (version) {
-                queryString += '&version=' + version;
-            }
-            if (author) {
-                queryString += '&author=' + author;
-            }
-            if (tags) {
-                queryString += '&tags=' + tags;
-            }
-            if (content) {
-                queryString += '&content=' + content;
-            }
-            if (createdFrom) {
-                queryString += '&createdFrom=' + date.getDateFromDateInput(createdFrom);
-            }
-            if (createdTo) {
-                queryString += '&createdTo=' + date.getDateFromDateInput(createdTo);
-            }
-            if (modifiedFrom) {
-                queryString += '&modifiedFrom=' + date.getDateFromDateInput(modifiedFrom);
-            }
-            if (modifiedTo) {
-                queryString += '&modifiedTo=' + date.getDateFromDateInput(modifiedTo);
-            }
-
-            if (this.attributes.length) {
-                queryString += '&attributes=';
-                this.attributes.each(function (attribute) {
-                    var type = attribute.get('type') || attribute.get('attributeType');
-                    var name = attribute.get('name');
-                    var value = attribute.get('value') || '';
-                    value = type === 'BOOLEAN' ? (value ? 'true' : 'false') : value;
-                    value = type === 'LOV' ? attribute.get('items')[value].name : value;
-                    queryString += type + ':' + name + ':' + value + ';';
-                });
-                // remove last '+'
-                queryString = queryString.substr(0, queryString.length - 1);
-            }
-
-            queryString += '&from=0&size=10000';
-
-            return queryString;
-
+            var data = {
+                id: this.$id.val(),
+                title: this.$title.val(),
+                type: this.$type.val(),
+                version: this.$version.val(),
+                author: this.$author.val(),
+                tags: this.$tags.val().replace(/ /g, ''),
+                content: this.$content.val(),
+                createdFrom: this.$createdFrom.val() ? date.getDateFromDateInput(this.$createdFrom.val()) : null,
+                createdTo: this.$createdTo.val() ? date.getDateFromDateInput(this.$createdTo.val()) : null,
+                modifiedFrom: this.$modifiedFrom.val() ? date.getDateFromDateInput(this.$modifiedFrom.val()) : null,
+                modifiedTo: this.$modifiedTo.val() ? date.getDateFromDateInput(this.$modifiedTo.val()) : null,
+            };
+            return query.constructSearchQuery(data, this.attributes);
         }
 
     });

--- a/app/js/common-objects/utils/query.js
+++ b/app/js/common-objects/utils/query.js
@@ -1,0 +1,34 @@
+/*global define*/
+define([], function () {
+	'use strict';
+    var Query = {
+
+        constructSearchQuery: function (data, attributes) {
+            var queryString = '';
+            Object.keys(data).forEach(function(key) {
+                if(data[key]) {
+                    queryString += '&' + key + '=' + encodeURIComponent(data[key]);
+                }
+            });
+            if (attributes.length) {
+                queryString += '&attributes=';
+                attributes.each(function (attribute) {
+                    var type = attribute.get('type') || attribute.get('attributeType');
+                    var name = attribute.get('name');
+                    var value = attribute.get('value') || '';
+                    value = type === 'BOOLEAN' ? (value ? 'true' : 'false') : value;
+                    value = type === 'LOV' ? attribute.get('items')[value].name : value;
+                    queryString += type + ':' + name + ':' + value + ';';
+                });
+                // remove last '+'
+                queryString = queryString.substr(0, queryString.length - 1);
+            }
+
+            queryString += '&from=0&size=10000';
+            return queryString;
+        },
+    };
+
+    return Query;
+
+});

--- a/app/product-management/js/views/advanced_search.js
+++ b/app/product-management/js/views/advanced_search.js
@@ -7,8 +7,9 @@ define([
     'common-objects/views/attributes/attribute_list',
     'collections/part_templates',
     'common-objects/utils/date',
+    'common-objects/utils/query',
     'common-objects/collections/lovs'
-], function (Backbone, Mustache, template, Users, PartAttributeListView, Templates, date, LOVCollection) {
+], function (Backbone, Mustache, template, Users, PartAttributeListView, Templates, date, query, LOVCollection) {
     'use strict';
     var AdvancedSearchView = Backbone.View.extend({
 
@@ -107,7 +108,7 @@ define([
         onSubmitForm: function () {
             var queryString = this.constructQueryString();
             if (queryString) {
-                App.router.navigate(encodeURIComponent(App.config.workspaceId) + '/parts-search/' + encodeURIComponent(queryString), {trigger: true});
+                App.router.navigate(encodeURIComponent(App.config.workspaceId) + '/parts-search/' + queryString, {trigger: true});
                 this.closeModal();
             }
             return false;
@@ -143,78 +144,21 @@ define([
 
         constructQueryString: function () {
 
-            var number = this.$number.val();
-            var name = this.$name.val();
-            var type = this.$type.val();
-            var version = this.$version.val();
-            var author = this.$author.val();
-            var tags = this.$tags.val().replace(/ /g, '');
-            var createdFrom = this.$createdFrom.val();
-            var createdTo = this.$createdTo.val();
-            var modifiedFrom = this.$modifiedFrom.val();
-            var modifiedTo = this.$modifiedTo.val();
-            var standardPart = this.$standardPart.filter(':checked').val() === 'all' ? null : this.$standardPart.filter(':checked').val();
-            var content = this.$content.val();
-
-            var queryString = '';
-
-            if (number) {
-                queryString += '&number=' + number;
-            }
-            if (name) {
-                queryString += '&name=' + name;
-            }
-            if (type) {
-                queryString += '&type=' + type;
-            }
-            if (version) {
-                queryString += '&version=' + version;
-            }
-            if (author) {
-                queryString += '&author=' + author;
-            }
-            if (tags) {
-                queryString += '&tags=' + tags;
-            }
-            if (createdFrom) {
-                queryString += '&createdFrom=' + date.getDateFromDateInput(createdFrom);
-            }
-            if (createdTo) {
-                queryString += '&createdTo=' + date.getDateFromDateInput(createdTo);
-            }
-            if (modifiedFrom) {
-                queryString += '&modifiedFrom=' + date.getDateFromDateInput(modifiedFrom);
-            }
-            if (modifiedTo) {
-                queryString += '&modifiedTo=' + date.getDateFromDateInput(modifiedTo);
-            }
-            if (standardPart) {
-                queryString += '&standardPart=' + standardPart;
-            }
-            if (content) {
-                queryString += '&content=' + content;
-            }
-
-            if (this.attributes.length) {
-                queryString += '&attributes=';
-                this.attributes.each(function (attribute) {
-                    var type = attribute.get('type') || attribute.get('attributeType');
-                    var name = attribute.get('name');
-                    var value = attribute.get('value')|| '';
-                    value = type === 'BOOLEAN' ? (value ? 'true' : 'false') : value;
-                    value = type === 'LOV' ? attribute.get('items')[value].name : value;
-                    queryString += type + ':' + name + ':' + value + ';';
-                });
-                // remove last '+'
-                queryString = queryString.substr(0, queryString.length - 1);
-            }
-            //replace first occurrence of & to ?
-            queryString = queryString.replace('&','?');
-
-            queryString += '&from=0&size=10000';
-
-            return queryString;
-
+            var data = {
+                number: this.$number.val(),
+                name: this.$name.val(),
+                type: this.$type.val(),
+                version: this.$version.val(),
+                author: this.$author.val(),
+                tags: this.$tags.val().replace(/ /g, ''),
+                content: this.$content.val(),
+                createdFrom: this.$createdFrom.val() ? date.getDateFromDateInput(this.$createdFrom.val()) : null,
+                createdTo: this.$createdTo.val() ? date.getDateFromDateInput(this.$createdTo.val()) : null,
+                modifiedFrom: this.$modifiedFrom.val() ? date.getDateFromDateInput(this.$modifiedFrom.val()) : null,
+                modifiedTo: this.$modifiedTo.val() ? date.getDateFromDateInput(this.$modifiedTo.val()) : null,
+                standardPart: this.$standardPart.filter(':checked').val() === 'all' ? null : this.$standardPart.filter(':checked').val()
+            };
+            return query.constructSearchQuery(data, this.attributes);
         }
 
     });


### PR DESCRIPTION
Before this fix the search query was encoded as whole so we have issues
when search for values that conatins special characters like &. For
example if we are searching for a title like foo&bar, the backend will
that we are searching for title=foo and bar=<empty>.

Fixes #50