### PR TITLE
QueryBuilder displaying errors resolved

### DIFF
--- a/app/product-management/js/views/part/part_content.js
+++ b/app/product-management/js/views/part/part_content.js
@@ -56,7 +56,8 @@ define([
             'click .display-query-builder-button': 'toggleQueryBuilder',
             'click .import': 'showImporter',
             'click button[value="all"]': 'showAllWithTask',
-            'click button[value="in_progress"]': 'showTaskInProgress'
+            'click button[value="in_progress"]': 'showTaskInProgress',
+            'click .reset-button':'onReset'
         },
 
         partials: {
@@ -173,6 +174,10 @@ define([
             this.partListView.on('new-product-button:display', this.changeNewProductButtonDisplay);
             this.queryBuilder.on('query:search', this.onQueryBuilderSearch);
             this.delegateEvents();
+        },
+
+        onReset:function(){
+            this.$queryTableContainer.empty();
         },
 
         onQueryBuilderSearch: function (data) {
@@ -563,6 +568,7 @@ define([
             this.$el.toggleClass('displayQueryBuilder', this.isQueryBuilderDisplayed);
             this.$displayQueryBuilderButton.toggleClass('fa-angle-double-down', !this.isQueryBuilderDisplayed);
             this.$displayQueryBuilderButton.toggleClass('fa-angle-double-up', this.isQueryBuilderDisplayed);
+            this.$queryTableContainer.empty();
             this.$queryTableContainer.toggle(this.isQueryBuilderDisplayed);
             this.$partTableContainer.toggle(!this.isQueryBuilderDisplayed);
             this.pageControls.toggle(!this.isQueryBuilderDisplayed);


### PR DESCRIPTION
Resolve troubles ( from [issue-23](https://github.com/docdoku/docdoku-web-front/issues/23)): 

   - Display old search result when user close and re-open queryBuilder view.
   - Display old search result when user click on reset button.